### PR TITLE
Tame resource allocation

### DIFF
--- a/chancellor.rb
+++ b/chancellor.rb
@@ -5,13 +5,18 @@ require_relative 'domain/staging'
 require_relative 'domain/production'
 
 class Chancellor < Sinatra::Base
+  configure do
+    set :production, Production.new
+    set :staging, Staging.new
+  end
+
   helpers do
     def production
-      @productionn ||= Production.new
+      settings.production
     end
 
     def staging
-      @staging ||= Staging.new
+      settings.staging
     end
 
     def render_as_json(success)

--- a/domain/environment.rb
+++ b/domain/environment.rb
@@ -7,6 +7,10 @@ class Environment
       @script = command
     end
     attr_reader :script
+
+    def redis
+      @@redis ||= Redis.new(url: ENV['REDISTOGO_URL'])
+    end
   end
 
   def script
@@ -38,7 +42,6 @@ class Environment
   end
 
   def redis
-    @redis ||= Redis::Namespace.new(self.class.to_s.downcase,
-      redis: Redis.new(url: ENV['REDISTOGO_URL']))
+    @redis ||= Redis::Namespace.new(self.class.to_s.downcase, redis: self.class.redis)
   end
 end


### PR DESCRIPTION
When deployed onto Heroku the app was maxing out the number of Redis connections allowed with the free instance we're currently using.

This changeset ensures a singleton connection.

@andrewgarner 
