### PR TITLE
Multiple scripts per environment

### DIFF
--- a/chancellor.rb
+++ b/chancellor.rb
@@ -3,6 +3,7 @@ require 'json'
 
 require_relative 'domain/staging'
 require_relative 'domain/production'
+require_relative 'lib/script_runner'
 
 class Chancellor < Sinatra::Base
   configure do

--- a/domain/environment.rb
+++ b/domain/environment.rb
@@ -18,9 +18,9 @@ class Environment
   end
 
   def check
-    output = run_script(script)
-    redis.set(:status, exit_status)
-    redis.set(:output, output)
+    result = ScriptRunner.run(script)
+    redis.set(:status, result.status)
+    redis.set(:output, result.output)
   end
 
   def success?
@@ -32,14 +32,6 @@ class Environment
   end
 
   private
-
-  def run_script(command)
-    %x(#{command} 2>&1)
-  end
-
-  def exit_status
-    $?.exitstatus
-  end
 
   def redis
     @redis ||= Redis::Namespace.new(self.class.to_s.downcase, redis: self.class.redis)

--- a/lib/script_runner.rb
+++ b/lib/script_runner.rb
@@ -1,0 +1,17 @@
+class ScriptRunner < Struct.new(:output, :status)
+  class << self
+    def run(script)
+      new(run_script(script), exit_status)
+    end
+
+    private
+
+    def run_script(command)
+      %x(#{command} 2>&1)
+    end
+
+    def exit_status
+      $?.exitstatus
+    end
+  end
+end

--- a/spec/domain/environment_spec.rb
+++ b/spec/domain/environment_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Environment do
     redis.flushdb
   end
 
-  specify { expect(environment.script).to eql(script_to_run) }
+  specify { expect(environment.scripts).to eql([script_to_run]) }
 
   describe '#check' do
     before do
@@ -36,7 +36,7 @@ RSpec.describe Environment do
     end
 
     specify { expect(redis.get(status_field)).to eql(status.to_s) }
-    specify { expect(redis.get(output_field)).to eql(output) }
+    specify { expect(redis.get(output_field)).to eql("#{output}\n") }
   end
 
   describe '#success?' do

--- a/spec/domain/environment_spec.rb
+++ b/spec/domain/environment_spec.rb
@@ -1,4 +1,5 @@
 require 'domain/environment'
+require 'lib/script_runner'
 
 RSpec.describe Environment do
   let(:script_to_run) { './bin/smoke_test' }
@@ -17,6 +18,7 @@ RSpec.describe Environment do
   let(:output_field) { "#{environment_name}:output" }
   let(:status) { 0 }
   let(:output) { 'output' }
+  let(:script_result) { double(output: output, status: status) }
   let(:redis) { Redis.new }
 
   subject(:environment) { environment_class.new }
@@ -29,8 +31,7 @@ RSpec.describe Environment do
 
   describe '#check' do
     before do
-      allow(environment).to receive(:run_script).with(script_to_run).and_return(output)
-      allow(environment).to receive(:exit_status).and_return(status)
+      allow(ScriptRunner).to receive(:run).with(script_to_run).and_return(script_result)
       environment.check
     end
 

--- a/spec/domain/environment_with_multiple_scripts_spec.rb
+++ b/spec/domain/environment_with_multiple_scripts_spec.rb
@@ -1,0 +1,64 @@
+require 'domain/environment'
+require 'lib/script_runner'
+
+RSpec.describe Environment, 'with multiple scripts' do
+  let(:script_1) { './bin/script_1' }
+  let(:script_2) { './bin/script_2' }
+  let(:environment_name) { 'testing_more' }
+  let(:environment_class) do
+    if Object.const_defined?(environment_name.capitalize)
+      Object.const_get(environment_name.capitalize)
+    else
+      str_1 = script_1
+      str_2 = script_2
+      Object.const_set(environment_name.capitalize, Class.new(described_class) do
+        run str_1
+        run str_2
+      end)
+    end
+  end
+  let(:status_field) { "#{environment_name}:status" }
+  let(:output_field) { "#{environment_name}:output" }
+  let(:status_1) { 0 }
+  let(:output_1) { 'output 1' }
+  let(:status_2) { 0 }
+  let(:output_2) { 'output 2' }
+  let(:result_1) { double(output: output_1, status: status_1) }
+  let(:result_2) { double(output: output_2, status: status_2) }
+  let(:redis) { Redis.new }
+
+  subject(:environment) { environment_class.new }
+
+  before do
+    redis.flushdb
+  end
+
+  specify { expect(environment.scripts).to eql([script_1, script_2]) }
+
+  describe '#check' do
+    before do
+      allow(ScriptRunner).to receive(:run).with(script_1).and_return(result_1)
+      allow(ScriptRunner).to receive(:run).with(script_2).and_return(result_2)
+      environment.check
+    end
+
+    context 'when all scripts pass' do
+      specify { expect(redis.get(status_field)).to eql('0') }
+      specify { expect(redis.get(output_field)).to eql("#{output_1}\n#{output_2}\n") }
+    end
+
+    context 'when the first script fails' do
+      let(:status_1) { 1 }
+
+      specify { expect(redis.get(status_field)).to eql('1') }
+      specify { expect(redis.get(output_field)).to eql("#{output_1}\n") }
+    end
+
+    context 'when the second script fails' do
+      let(:status_2) { 1 }
+
+      specify { expect(redis.get(status_field)).to eql('1') }
+      specify { expect(redis.get(output_field)).to eql("#{output_1}\n#{output_2}\n") }
+    end
+  end
+end

--- a/spec/lib/script_runner_spec.rb
+++ b/spec/lib/script_runner_spec.rb
@@ -1,0 +1,18 @@
+require 'lib/script_runner'
+
+RSpec.describe ScriptRunner, '.run' do
+  let(:script) { './bin/smoke_test' }
+  let(:status) { 0 }
+  let(:output) { 'output' }
+
+  before do
+    allow(described_class).to receive(:run_script).and_return(output)
+    allow(described_class).to receive(:exit_status).and_return(status)
+  end
+
+  subject(:result) { described_class.run(script) }
+
+  it { is_expected.to be_a(described_class) }
+  specify { expect(result.output).to eq(output) }
+  specify { expect(result.status).to eq(status) }
+end


### PR DESCRIPTION
We want to run smoke tests for the output document generator.

This PR allows us to run multiple smoke test scripts per environment which will allow for something descended from [my POC](https://gist.github.com/stevenwilkin/8095b3d5b923c55d1aec) be run.
