### PR TITLE
Replace hidden location

### DIFF
--- a/bin/cab_locator_test.rb
+++ b/bin/cab_locator_test.rb
@@ -33,7 +33,7 @@ else
 end
 
 form = page.form_with(action: '/locations')
-form['postcode'] = 'SW1A 2HQ'
+form['postcode'] = 'RG2 9AF'
 page = form.submit(form.buttons.first)
 
 if page.body =~ /Face-to-face locations near/
@@ -44,7 +44,7 @@ end
 
 page = page.link_with(dom_class: 't-name').click
 
-if page.body =~ /Camden/
+if page.body =~ /Wokingham/
   puts '> Renders location'
 else
   raise 'Should render location'


### PR DESCRIPTION
Camden had been hidden by an administrator. This change ensures we are
checking on a location that is currently visible.

Smoke tests will fail until this gets merged.
