### PR TITLE
Planner backend test

### DIFF
--- a/bin/planner_backend_test.rb
+++ b/bin/planner_backend_test.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'date'
+require 'mechanize'
+
+domain = ARGV[0]
+email = ENV['PLANNER_EMAIL']
+password = ENV['PLANNER_PASSWORD']
+
+puts ">> Checking #{domain} at #{Time.now}"
+
+mech = Mechanize.new
+
+page = mech.get(domain)
+
+if page.body =~ /Sign in/
+  puts '> Renders login form'
+else
+  raise 'Should render login form'
+end
+
+form = page.forms.first
+form['user[email]'] = email
+form['user[password]'] = password
+
+page = form.submit(form.buttons.first)
+
+if page.body =~ /Booking requests/
+  puts '> Renders logged in view'
+else
+  raise 'Should be logged in'
+end
+
+puts '>> OK'

--- a/domain/production.rb
+++ b/domain/production.rb
@@ -5,4 +5,5 @@ class Production < Environment
   run "./bin/cab_locator_test.rb #{ENV['PENSION_GUIDANCE_PRODUCTION_DOMAIN']}"
   run "./bin/output_document_test.rb #{ENV['OUTPUT_DOCUMENT_PRODUCTION_DOMAIN']}"
   run "./bin/twilio_redirect_test.rb #{ENV['TWILIO_REDIRECT_PRODUCTION_DOMAIN']}"
+  run "./bin/planner_backend_test.rb #{ENV['PLANNER_PRODUCTION_DOMAIN']}"
 end

--- a/domain/staging.rb
+++ b/domain/staging.rb
@@ -5,4 +5,5 @@ class Staging < Environment
   run "./bin/cab_locator_test.rb #{ENV['PENSION_GUIDANCE_STAGING_DOMAIN']}"
   run "./bin/output_document_test.rb #{ENV['OUTPUT_DOCUMENT_STAGING_DOMAIN']}"
   run "./bin/twilio_redirect_test.rb #{ENV['TWILIO_REDIRECT_STAGING_DOMAIN']}"
+  run "./bin/planner_backend_test.rb #{ENV['PLANNER_STAGING_DOMAIN']}"
 end


### PR DESCRIPTION
Just tests that signon is hooked up, the app loads and booking requests
are viewed, thus the locations API is also accessible.

I added configuration for the staging environment for completion-sake
but it's likely we'll remove the staging configuration across all
checks soon, since we get lots of false-negatives due to the time it
takes to spin up heroku dynos in the staging environments.
