### PR TITLE
Add checks for TAP

### DIFF
--- a/bin/tap_backend_test.rb
+++ b/bin/tap_backend_test.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'date'
+require 'mechanize'
+
+domain = ARGV[0]
+email = ENV['PLANNER_EMAIL']
+password = ENV['PLANNER_PASSWORD']
+
+puts ">> Checking #{domain} at #{Time.now}"
+
+mech = Mechanize.new
+
+page = mech.get(domain)
+
+if page.body =~ /Sign in/
+  puts '> Renders login form'
+else
+  raise 'Should render login form'
+end
+
+form = page.forms.first
+form['user[email]'] = email
+form['user[password]'] = password
+
+page = form.submit(form.buttons.first)
+
+if page.body =~ /Waheeda No/
+  puts '> Renders logged in view'
+else
+  raise 'Should be logged in'
+end
+
+puts '>> OK'

--- a/domain/production.rb
+++ b/domain/production.rb
@@ -6,4 +6,5 @@ class Production < Environment
   run "./bin/output_document_test.rb #{ENV['OUTPUT_DOCUMENT_PRODUCTION_DOMAIN']}"
   run "./bin/twilio_redirect_test.rb #{ENV['TWILIO_REDIRECT_PRODUCTION_DOMAIN']}"
   run "./bin/planner_backend_test.rb #{ENV['PLANNER_PRODUCTION_DOMAIN']}"
+  run "./bin/tap_backend_test.rb #{ENV['TAP_PRODUCTION_DOMAIN']}"
 end

--- a/domain/staging.rb
+++ b/domain/staging.rb
@@ -6,4 +6,5 @@ class Staging < Environment
   run "./bin/output_document_test.rb #{ENV['OUTPUT_DOCUMENT_STAGING_DOMAIN']}"
   run "./bin/twilio_redirect_test.rb #{ENV['TWILIO_REDIRECT_STAGING_DOMAIN']}"
   run "./bin/planner_backend_test.rb #{ENV['PLANNER_STAGING_DOMAIN']}"
+  run "./bin/tap_backend_test.rb #{ENV['TAP_STAGING_DOMAIN']}"
 end


### PR DESCRIPTION
This simply logs the smoke test user in, redirects to the allocations
view (since the smoke test user has the `resource_manager` permission)
and checks that Waheeda appears as an available resource.