### PR TITLE
Check for the correct message from output

### DIFF
--- a/bin/output_document_test.rb
+++ b/bin/output_document_test.rb
@@ -26,7 +26,7 @@ form['user[password]'] = password
 
 page = form.submit(form.buttons.first)
 
-if page.body =~ /issue a summary document/
+if page.body =~ /Create appointment summary/
   puts '> Renders logged in view'
 else
   raise 'Should be logged in'


### PR DESCRIPTION
The behaviour changed since summary documents are now only created via
the TAP integration, so we should check for the presence of the correct
message to verify the app is accessible from a permitted signon user.